### PR TITLE
Let users choose to use the polling monitor

### DIFF
--- a/libfswatch.nimble
+++ b/libfswatch.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Paul Nameless"
 description   = "Nim binding to libfswatch"
 license       = "MIT"

--- a/src/libfswatch.nim
+++ b/src/libfswatch.nim
@@ -42,7 +42,14 @@ type
     filter_type*: fsw_filter_type
     case_sensitive*: bool
     extended*: bool
-
+  fsw_monitor_type* = enum
+    system_default_monitor_type = 0,
+    fsevents_monitor_type,
+    kqueue_monitor_type,
+    inotify_monitor_type,
+    windows_monitor_type,
+    poll_monitor_type,
+    fen_monitor_type
 
 proc fsw_init_library*(): cint {.importc, dynlib: libName.}
 

--- a/src/libfswatch/fswatch.nim
+++ b/src/libfswatch/fswatch.nim
@@ -5,11 +5,11 @@ type
     handle*: ptr fsw_handle
 
 
-proc newMonitor*(): Monitor =
+proc newMonitor*(monitor_type:fsw_monitor_type = system_default_monitor_type): Monitor =
   if fsw_init_library() != 0:
     echo "Error init library"
     quit(QuitFailure)
-  result.handle = fsw_init_session(0)
+  result.handle = fsw_init_session(monitor_type.cint)
 
 proc addPath*(monitor: Monitor, path: string) =
   if monitor.handle.fsw_add_path(path) != 0:


### PR DESCRIPTION
With this change, I can do:

```nim
newMonitor(poll_monitor_type)
```

inside my Docker container that doesn't do well with the default type.